### PR TITLE
Added capability to open the selected file in a new tab.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ If you use neovim, you have to add the dependency to the plugin bclose.vim:
 How to use it
 =============
 
-The default shortcut for opening Ranger is <leade>f (\f by default) 
-For disable the default key mapping, add this line in your .vimrc or init.vim: `let g:ranger_map_keys = 0`
+The default shortcut for opening Ranger is <leader>f (\f by default) 
+To disable the default key mapping, add this line in your .vimrc or init.vim: `let g:ranger_map_keys = 0`
 
 then you can add a new mapping with this line: `map <leader>f :Ranger<CR>`.
+
+To open the selected file in a new tab, instead of the current tab (the default behaviour) - add this line in your .vimrc or init.vim: `let g:ranger_open_new_tab = 1`
 
 The command for opening ranger is `:Ranger`.
 

--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -33,7 +33,7 @@ if has('nvim')
         if filereadable('/tmp/chosenfile')
           exec system('sed -ie "s/ /\\\ /g" /tmp/chosenfile')
           exec 'argadd ' . system('cat /tmp/chosenfile | tr "\\n" " "')
-          exec 'edit ' . system('head -n1 /tmp/chosenfile')
+          exec s:edit_cmd . system('head -n1 /tmp/chosenfile')
           call system('rm /tmp/chosenfile')
         endif
       endtry
@@ -48,19 +48,21 @@ else
     if filereadable('/tmp/chosenfile')
       exec system('sed -ie "s/ /\\\ /g" /tmp/chosenfile')
       exec 'argadd ' . system('cat /tmp/chosenfile | tr "\\n" " "')
-      exec 'edit ' . system('head -n1 /tmp/chosenfile')
+      exec s:edit_cmd . system('head -n1 /tmp/chosenfile')
       call system('rm /tmp/chosenfile')
     endif
     redraw!
   endfun
 endif
 
-if !exists('g:ranger_map_keys')
-  let g:ranger_map_keys = 1
+if !exists('g:ranger_map_keys') || g:ranger_map_keys
+  map <leader>f :call OpenRanger()<CR>
 endif
 
-if g:ranger_map_keys
-  map <leader>f :call OpenRanger()<CR>
+if exists('g:ranger_open_new_tab') && g:ranger_open_new_tab
+  let s:edit_cmd='tabedit '
+else
+  let s:edit_cmd='edit '
 endif
 
 command! Ranger call OpenRanger()


### PR DESCRIPTION
 If the variable g:ranger_open_new_tab is set and is truethy - the
script now uses tabedit, instead of edit, to open the selected file.
The variable s:edit_cmd now holds the command to be used when opening
the selected file.