### PR TITLE
Add commands to make vim open the selected files in a new tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ To disable the default key mapping, add this line in your .vimrc or init.vim: `l
 
 then you can add a new mapping with this line: `map <leader>f :Ranger<CR>`.
 
-To open the selected file in a new tab, instead of the current tab (the default behaviour) - add this line in your .vimrc or init.vim: `let g:ranger_open_new_tab = 1`
+The command for opening Ranger in the current file's directory is `:Ranger`.
+Vim will open the selected file in the current window. To open the selected
+file in a new tab instead use `:RangerNewTab`.
 
-The command for opening Ranger in the current file's directory is `:Ranger`. For opening Ranger in the current workspace, run `:RangerWorkingDirectory`
+For opening Ranger in the current workspace, run `:RangerWorkingDirectory`.
+Vim will open the selected file in the current window.
+`:RangerWorkingDirectoryNewTab` will open the selected file in a new tab instead.
+
+The old way to make vim open the selected file in a new tab was to add
+`let g:ranger_open_new_tab = 1` in your .vimrc or init.vim. That way is still
+supported but deprecated.


### PR DESCRIPTION
Added commands:

- RangerWorkingDirectoryNewTab
- RangerCurrentDirectoryNewTab
- RangerNewTab (alias of RangerCurrentDirectoryNewTab)

Updated the README.

`let g:ranger_open_new_tab = 1` still works but is now deprecated.