### PR TITLE
Fix ranger open parent directory instead of the current directory

### DIFF
--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -39,7 +39,11 @@ if has('nvim')
       endtry
     endfunction
     enew
-    call termopen('ranger --choosefiles=/tmp/chosenfile --selectfile="' . currentPath . '"', rangerCallback)
+    if isdirectory(currentPath)
+      call termopen('ranger --choosefiles=/tmp/chosenfile "' . currentPath . '"', rangerCallback)
+    else
+      call termopen('ranger --choosefiles=/tmp/chosenfile --selectfile="' . currentPath . '"', rangerCallback)
+    endif
     startinsert
   endfunction
 else


### PR DESCRIPTION
This change allow open the current directory instead the parent directory with the current directory selected, and if the current directory have a file selected it open the current directory with the selected file.

More info on issue #40 

Note: Change is only for NeoVIM.