### PR TITLE
Open ranger when using :edit on a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ The old way to make vim open the selected file in a new tab was to add
 supported but deprecated.
 
 ### Opening ranger instead of netrw when you open a directory
-** currently works with neovim only ** (see the issue #45) 
-If you want to see vim opening ranger when you open a directory (ex: nvim ./dir), please add this in your .(n)vimrc.
+If you want to see vim opening ranger when you open a directory (ex: nvim ./dir or :edit ./dir), please add this in your .(n)vimrc.
 ```
 let g:NERDTreeHijackNetrw = 0 // add this line if you use NERDTree
 let g:ranger_replace_netrw = 1 // open ranger when vim open a directory
 ```
+
+In order for this to work you need to install the bclose.vim plugin (see above).
 
 ### Setting an other path for the temporary file
 Ranger.vim uses a temporary file to store the path that was chosen, `/tmp/chosenfile` by default.

--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -109,7 +109,7 @@ function! OpenRangerOnVimLoadDir(argv_path)
   let path = expand(a:argv_path)
 
   " Delete empty buffer created by vim
-  exec "bd!"
+  Bclose!
 
   " Open Ranger
   call OpenRangerIn(path, 'edit')

--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -120,7 +120,6 @@ if exists('g:ranger_replace_netrw') && g:ranger_replace_netrw
   augroup ReplaceNetrwByRangerVim
     autocmd VimEnter * silent! autocmd! FileExplorer
     autocmd StdinReadPre * let s:std_in=1
-    autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in") | call OpenRangerOnVimLoadDir(argv()[0]) | endif
     autocmd BufEnter * if isdirectory(expand("%")) | call OpenRangerOnVimLoadDir("%") | endif
   augroup END
 endif

--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -106,15 +106,13 @@ endfunction
 
 " Open Ranger in the directory passed by argument
 function! OpenRangerOnVimLoadDir(argv_path)
+  let path = expand(a:argv_path)
 
   " Delete empty buffer created by vim
-  exec "bp"
   exec "bd!"
 
   " Open Ranger
-  let path = expand(a:argv_path)
-  call OpenRangerIn(path, "edit")
-
+  call OpenRangerIn(path, 'edit')
 endfunction
 
 " To open ranger when vim load a directory
@@ -123,6 +121,7 @@ if exists('g:ranger_replace_netrw') && g:ranger_replace_netrw
     autocmd VimEnter * silent! autocmd! FileExplorer
     autocmd StdinReadPre * let s:std_in=1
     autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in") | call OpenRangerOnVimLoadDir(argv()[0]) | endif
+    autocmd BufEnter * if isdirectory(expand("%")) | call OpenRangerOnVimLoadDir("%") | endif
   augroup END
 endif
 


### PR DESCRIPTION
Fix #45 

NOTE: this may conflict with minibufexplorer

If minibufexplorer is loaded before ranger.vim an error could
trigger when using `:edit <directory>`

Make sure you put minibufexplorer after ranger.vim in the plugin
definition.

```
  " Ranger integration
  Plugin 'michelesr/ranger.vim'

  " Buffer explorer (load after ranger.vim)
  Plugin 'fholgado/minibufexpl.vim'
```

However, even if you use the right order sometimes the file chosen
by ranger will open in the minibufexplorer window instead of the
previous window: when this happens the window with the previous file 
will be still open and you will have to delete it manually.

Not sure how to avoid this cuz minibufexplorer is handling the same
`BufEnter` event and is relying on particolar window switch movements that
may brake when ranger.vim deletes the empty buffer.

EDIT: all these problems are solved simply by replacing `bd!` with `Bclose!`. Apparently deleting the buffer is causing different problems:

1) conflicts with minibufexplorer
2) deleting the window if there are splits

Bclose solve all the issues :-)