### PR TITLE
Fix #45 reset the filetype when opening ranger on VimEnter (with vim .)

### DIFF
--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -78,6 +78,9 @@ else
       call delete(s:choice_file_path)
     endif
     redraw!
+    " reset the filetype to fix the issue that happens
+    " when opening ranger on VimEnter (with `vim .`)
+    filetype detect
   endfun
 endif
 


### PR DESCRIPTION
Fix the issue when opening ranger on VimEnter (with vim .). See https://github.com/francoiscabrol/ranger.vim/pull/55#issuecomment-386845449