### PR TITLE
Remove Bclose

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ Install it with your favorite plugin manager. Example with vim-plug:
 
         Plug 'francoiscabrol/ranger.vim'
 
-If you use neovim, you have to add the dependency to the plugin bclose.vim:
-
-        Plug 'rbgrouleff/bclose.vim'
-
 How to use it
 -------------
 

--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -54,7 +54,7 @@ if has('nvim')
       "if ranger was closed regularly by selecting a file or quitting
       if a:code == 0
         try
-          "try to read the file containing the choisen files list
+          "try to read the file containing the chosen files list
           if filereadable(s:choice_file_path)
             "Open all the selected files
             for f in readfile(s:choice_file_path)
@@ -70,23 +70,28 @@ if has('nvim')
               silent! execute 'bdelete! '. self.oldBuffer
             else
               "but else it should select the old and then the last buffer to
-              "set correctly the buffer list
+              "set correctly the alternate buffer
               silent! execute 'buffer '. self.oldBuffer
               silent! execute 'buffer '.a:newFileBuff
             endif
           else
-            "Select the old alternate buffer (before opening ranger)
-            silent! execute 'buffer '. self.oldAltBuffer
-            "if the previous buffer is a directory, it means that ranger ran
-            "while opening vim
+            "Then check if the previous buffer is a directory
+            "it means that ranger ran while opening vim
             if isdirectory(self.oldPath)
               "Then it should remove this previous buffer
               silent! execute 'bdelete! '. self.oldBuffer
-              "and then opening a new empty one
-              enew
+              if self.oldAltBuffer
+                "select the old alternate buffer (before opening ranger)
+                silent! execute 'buffer '. self.oldAltBuffer
+              else
+                "or open a new empty one
+                enew
+              endif
             "but in any other case
             else
-              "it should move back to the previous buffer
+              "Select the old alternate buffer (before opening ranger)
+              silent! execute 'buffer '. self.oldAltBuffer
+              "Then move back to the previous buffer
               silent! execute 'buffer '. self.oldBuffer
             endif
           endif


### PR DESCRIPTION
@enthudave opened the PR #60 to fix an issue with the alternate buffer that was not well define after closing ranger.
I was trying to find an alternative implementation when I have seen a way to re-implement the neovim "rangerCallback" function without the use of the external dependency Bclose.
I wanted to remove Bclose since the beginning but I didn't find any other implementation keeping the same behaviours until now.

I know that there is probably some broken features so I open the PR to see if I get some interesting comments. During this time I will polish the implementation and make the thing totally stable.