### PR TITLE
Open files using relative paths (if they're shorter than absolute)

### DIFF
--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -57,9 +57,9 @@ if has('nvim')
           for f in readfile(s:choice_file_path)
             let relpath = system('realpath --relative-to=. ' . f)
             if strlen(relpath) < strlen(f)
-              exec a:edit_cmd . relpath
+              exec self.edit_cmd . relpath
             else
-              exec a:edit_cmd . f
+              exec self.edit_cmd . f
             endif
           endfor
           call delete(s:choice_file_path)

--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -55,7 +55,12 @@ if has('nvim')
       try
         if filereadable(s:choice_file_path)
           for f in readfile(s:choice_file_path)
-            exec self.edit_cmd . f
+            let relpath = system('realpath --relative-to=. ' . f)
+            if strlen(relpath) < strlen(f)
+              exec a:edit_cmd . relpath
+            else
+              exec a:edit_cmd . f
+            endif
           endfor
           call delete(s:choice_file_path)
         endif
@@ -79,7 +84,12 @@ else
     endif
     if filereadable(s:choice_file_path)
       for f in readfile(s:choice_file_path)
-        exec a:edit_cmd . f
+        let relpath = system('realpath --relative-to=. ' . f)
+        if strlen(relpath) < strlen(f)
+          exec a:edit_cmd . relpath
+        else
+          exec a:edit_cmd . f
+        endif
       endfor
       call delete(s:choice_file_path)
     endif

--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -55,9 +55,13 @@ if has('nvim')
       try
         if filereadable(s:choice_file_path)
           for f in readfile(s:choice_file_path)
-            let relpath = system('realpath --relative-to=. ' . f)
-            if strlen(relpath) < strlen(f)
-              exec self.edit_cmd . relpath
+            if executable('realpath')
+              let relpath = system('realpath --relative-to=. ' . f)
+              if strlen(relpath) < strlen(f)
+                exec self.edit_cmd . relpath
+              else
+                exec self.edit_cmd . f
+              endif
             else
               exec self.edit_cmd . f
             endif
@@ -84,12 +88,16 @@ else
     endif
     if filereadable(s:choice_file_path)
       for f in readfile(s:choice_file_path)
-        let relpath = system('realpath --relative-to=. ' . f)
-        if strlen(relpath) < strlen(f)
-          exec a:edit_cmd . relpath
-        else
-          exec a:edit_cmd . f
-        endif
+            if executable('realpath')
+              let relpath = system('realpath --relative-to=. ' . f)
+              if strlen(relpath) < strlen(f)
+                exec a:edit_cmd . relpath
+              else
+                exec a:edit_cmd . f
+              endif
+            else
+              exec a:edit_cmd . f
+            endif
       endfor
       call delete(s:choice_file_path)
     endif


### PR DESCRIPTION
Files that are selected with ranger are now opened using a path relative to the working directory, rather than an absolute path if the former is shorter. This behaviour produces better tab names since nearby files in a project are likely to be shown relative, whilst files being worked on elsewhere in the system are shown by their absolute path(s). Files in the same directory do not include any path information.