### PR TITLE
Update local current directory after opening a file

### DIFF
--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -57,6 +57,8 @@ if has('nvim')
           for f in readfile(s:choice_file_path)
             exec self.edit_cmd . f
           endfor
+          let currentWorkingDirectory = getcwd()
+          :execute "lcd " . currentWorkingDirectory
           call delete(s:choice_file_path)
         endif
       endtry


### PR DESCRIPTION
This shortens the path displayed in the buffer list `:ls`.