### PR TITLE
use tempname() as default s:choice_file_path

### DIFF
--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -41,7 +41,7 @@ else
 endif
 
 if !exists('s:choice_file_path')
-  let s:choice_file_path = '/tmp/chosenfile'
+  let s:choice_file_path = tempname()
 endif
 
 if has('nvim')


### PR DESCRIPTION
Using `tempname()` will prevent multiple instances writing/reading to the same file.