### PR TITLE
Added compatibility with suda.vim plugin

### DIFF
--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -44,9 +44,18 @@ if !exists('s:choice_file_path')
   let s:choice_file_path = '/tmp/chosenfile'
 endif
 
+function! s:parse_path(path)
+  let parsed = expand(a:path)
+  " suda compatibility
+  if exists('g:suda#prefix')
+    let parsed = substitute(parsed, g:suda#prefix, '', '')
+  endif
+  return parsed
+endfunction
+
 if has('nvim')
   function! OpenRangerIn(path, edit_cmd)
-    let currentPath = expand(a:path)
+    let currentPath = s:parse_path(a:path)
     let rangerCallback = { 'name': 'ranger', 'edit_cmd': a:edit_cmd }
     function! rangerCallback.on_exit(job_id, code, event)
       if a:code == 0
@@ -71,7 +80,7 @@ if has('nvim')
   endfunction
 else
   function! OpenRangerIn(path, edit_cmd)
-    let currentPath = expand(a:path)
+    let currentPath = s:parse_path(a:path)
     if isdirectory(currentPath)
       silent exec '!' . s:ranger_command . ' --choosefiles=' . s:choice_file_path . ' "' . currentPath . '"'
     else


### PR DESCRIPTION
[suda.vim](https://github.com/lambdalisue/suda.vim) is a plugin which lets you open files with sudo by using a protocol prefix, and/or automatically when opening a file that is missing read or write permissions.

Because the file path in vim is changed to `suda://[the file path]` this was causing the program to pass non-existent paths to range, causing it to immediately exit. So this compatibility patch just removes that prefix if suda is installed.

I don't have any experience with vimscript but I don't think there should be any issues on such a small change. I moved the path code into its own function to prevent repeat code.